### PR TITLE
chore: update ilp-core to 9.1.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   node:
-    version: 5.11.1
+    version: 6.9.1
 test:
   override:
     - npm run lint

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "docs": "npm run docs:api && npm run docs:toc",
     "integration": "integration all"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/interledgerjs/ilp.git"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "canonical-json": "0.0.4",
     "debug": "^2.2.0",
     "eventemitter2": "^2.0.0",
-    "ilp-core": "^9.0.0",
+    "ilp-core": "^9.1.1",
     "moment": "^2.14.1",
     "node-uuid": "^1.4.7"
   },


### PR DESCRIPTION
Adds support for passing a plugin by reference.