### PR TITLE
chore: switch to integration-test-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "docs:api": "jsdoc2md --global-index-format none \"src/**/*.js\" --template docs/README.template.md > docs/README.intermediate.md",
     "docs:toc": "md-toc-filter docs/README.intermediate.md > README.md",
     "docs": "npm run docs:api && npm run docs:toc",
-    "integration": "integration all"
+    "integration": "integration-loader && integration all"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -55,7 +55,7 @@
     "eslint-config-standard": "^5.3.5",
     "eslint-plugin-promise": "^2.0.0",
     "eslint-plugin-standard": "^2.0.0",
-    "five-bells-integration-test": "^4.0.0",
+    "five-bells-integration-test-loader": "^1.0.0",
     "ghooks": "^1.3.2",
     "istanbul": "^0.4.4",
     "jsdoc-to-markdown": "^1.3.6",
@@ -75,6 +75,10 @@
     },
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
+    },
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
     }
   }
 }


### PR DESCRIPTION
Currently, we have to bump the version of integration tests on every module, every time we change them. We also often get into deadlocks we have to resolve by skipping tests.

This is part of a series of pull requests to switch to five-bells-integration-test-loader, which will solve both problems by loading the integration tests according to the same rules as other modules: Use latest master, unless there is a branch of the same name, then use that branch.

It's probably easiest to understand by looking at the following two links:
* interledgerjs/five-bells-ledger@b241d14768b02a42a34dc42e91d5101db7de0525
* https://github.com/interledgerjs/five-bells-integration-test-loader