### PR TITLE
fix: race condition when receiving fulfillment

### DIFF
--- a/src/lib/sender.js
+++ b/src/lib/sender.js
@@ -141,6 +141,8 @@ function createSender (opts) {
     const payment = Object.assign(paymentParams, {
       uuid: transferId
     })
+
+    let promiseFulfillmentListener
     debug('sending payment:', payment)
     return client.connect()
       .then(() => client.sendQuotedPayment(payment))
@@ -148,25 +150,9 @@ function createSender (opts) {
         if (err.name !== 'DuplicateIdError') {
           throw err
         }
-
-        // If it's a duplicate, try getting the fulfillment for that transfer
-        // TODO also get the fulfillment if a transfer is rejected because the condition has already been fulfilled by another transfer
-        return client.getPlugin().getFulfillment(transferId)
-          .catch((err) => {
-            // If the transfer hasn't yet been fulfilled we'll wait for the event in the next handler
-            if (err.name === 'MissingFulfillmentError') {
-              return null
-            }
-            throw err
-          })
       })
-      .then((fulfillment) => {
-        if (fulfillment) {
-          debug('payment was already fulfilled: ' + fulfillment)
-          return fulfillment
-        }
-        debug('payment sent', payment)
-        return new Promise((resolve, reject) => {
+      .then(() => {
+        promiseFulfillmentListener = new Promise((resolve, reject) => {
           // TODO just have one listener for the client
           const transferTimeout = setTimeout(() => {
             debug('transfer timed out')
@@ -185,6 +171,25 @@ function createSender (opts) {
           // TODO disconnect from the client if there are no more listeners
           client.on('outgoing_fulfill', fulfillmentListener)
         })
+
+        // If it's a duplicate, try getting the fulfillment for that transfer
+        // TODO also get the fulfillment if a transfer is rejected because the condition has already been fulfilled by another transfer
+        return Promise.resolve(client.getPlugin().getFulfillment(transferId))
+      })
+      .catch((err) => {
+        // If the transfer hasn't yet been fulfilled we'll wait for the event in the next handler
+        if (err.name === 'MissingFulfillmentError') {
+          return null
+        }
+        throw err
+      })
+      .then((fulfillment) => {
+        if (fulfillment) {
+          debug('payment was already fulfilled: ' + fulfillment)
+          return fulfillment
+        }
+        debug('payment sent', payment)
+        return promiseFulfillmentListener
       })
   }
 

--- a/test/mocks/mockCore.js
+++ b/test/mocks/mockCore.js
@@ -1,11 +1,14 @@
 'use strict'
 
 const EventEmitter = require('eventemitter2')
+const CustomError = require('custom-error-instance')
 
 class Client extends EventEmitter {
   constructor (opts) {
     super()
     this.account = opts.account
+
+    const MissingFulfillmentError = CustomError('MissingFulfillmentError', { message: 'Missing fulfillment' })
     this.plugin = {
       getAccount: () => this.account,
       getInfo: () => ({
@@ -17,7 +20,7 @@ class Client extends EventEmitter {
         this.rejected = true
         return Promise.resolve()
       },
-      getFulfillment: () => 'cf:fulfillment'
+      getFulfillment: () => { throw new MissingFulfillmentError('not yet fulfilled') }
     }
     this.rejected = false
   }

--- a/test/senderSpec.js
+++ b/test/senderSpec.js
@@ -313,7 +313,17 @@ describe('Sender Module', function () {
         expect(stub).to.have.been.calledWith(this.paymentParams)
       })
 
-      it('should resolve to the transfer\'s condition fulfillment', function * () {
+      it('should resolve to the transfer\'s condition fulfillment when the fulfillment is ready immediately', function * () {
+        const stub = sinon.stub(this.client, 'sendQuotedPayment', (transfer) => Promise.resolve(transfer))
+        const stub2 = sinon.stub(this.client.getPlugin(), 'getFulfillment')
+        stub2.resolves('fulfillment')
+        const fulfillment = yield this.sender.payRequest(this.paymentParams)
+        expect(fulfillment).to.equal('fulfillment')
+        expect(stub).to.be.calledOnce
+        expect(stub2).to.be.calledOnce
+      })
+
+      it('should resolve to the transfer\'s condition fulfillment when the fulfillment is emitted as an event', function * () {
         const stub = sinon.stub(this.client, 'sendQuotedPayment')
         stub.resolves(new Promise((resolve) => {
           setImmediate(() => this.client.emit('outgoing_fulfill', {
@@ -432,7 +442,7 @@ describe('Sender Module', function () {
           this.sender.payRequest(this.paymentParams)
         ])
         expect(stub).to.be.calledTwice
-        expect(fulfillmentStub).to.be.calledOnce
+        expect(fulfillmentStub).to.be.calledTwice
         expect(results).to.deep.equal(['fulfillment', 'fulfillment'])
       })
 
@@ -455,7 +465,7 @@ describe('Sender Module', function () {
           this.sender.payRequest(this.paymentParams)
         ])
         expect(stub).to.be.calledTwice
-        expect(fulfillmentStub).to.be.calledOnce
+        expect(fulfillmentStub).to.be.calledTwice
         expect(results).to.deep.equal(['fulfillment', 'fulfillment'])
       })
 
@@ -488,4 +498,3 @@ describe('Sender Module', function () {
     })
   })
 })
-


### PR DESCRIPTION
Transfers may be fulfilled between when the sender is checking if they are fulfilled and when the sender starts listening to `outgoing_fulfilled` events.