### PR TITLE
fix: don't modify amounts from packet

### DIFF
--- a/src/lib/receiver.js
+++ b/src/lib/receiver.js
@@ -257,7 +257,7 @@ function createReceiver (opts) {
 
     const paymentRequest = {
       address: packet.account,
-      amount: (new BigNumber(packet.amount)).toString(),
+      amount: packet.amount,
       expires_at: packet.data && packet.data.expires_at
     }
 

--- a/src/lib/receiver.js
+++ b/src/lib/receiver.js
@@ -335,7 +335,15 @@ function createReceiver (opts) {
       .then(() => null)
       .catch((err) => {
         debug('reviewPayment got error', err)
-        return rejectIncomingTransfer(transfer.id, 'rejected-by-receiver: ' + err.name + ': ' + err.message)
+        let errorMessage
+        if (err instanceof Error) {
+          errorMessage = err.name + ': ' + err.message
+        } else if (typeof err === 'string') {
+          errorMessage = err
+        } else {
+          errorMessage = 'reason not specified'
+        }
+        return rejectIncomingTransfer(transfer.id, 'rejected-by-receiver: ' + errorMessage)
       })
 
     // returning the promise is only so the result is picked up by the tests' emitAsync


### PR DESCRIPTION
the receiver was parsing and then re-stringifying the numbers, causing the receiver not to accept payments from the sender with trailing zeros in the amount

depends on https://github.com/interledgerjs/five-bells-service-manager/pull/17