### PR TITLE
Feat: retry fulfillCondition automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,9 +302,7 @@ SPSP query response
 | minimum_destination_amount | <code>string</code> | Integer string representing the minimum that the receiver will be willing to accept. |
 | ledger_info | <code>Object</code> | An object containing the receiver's ledger metadata. |
 | ledger_info.currency_code | <code>string</code> | The currency code of the receiver's ledger. |
-| ledger_info.currency_symbol | <code>string</code> | The currency symbol of the receiver's ledger. |
-| ledger_info.precision | <code>string</code> | The precision of the receiver's ledger. |
-| ledger_info.scale | <code>string</code> | The scale of the receiver's ledger. |
+| ledger_info.currency_scale | <code>string</code> | The currency scale of the receiver's ledger. |
 | receiver_info | <code>Object</code> | Additional information containing arbitrary fields. |
 
 
@@ -345,7 +343,9 @@ Create a payment request using a Pre-Shared Key (PSK).
 | [params.data] | <code>Buffer</code> | <code></code> | Additional data to include in the request |
 | [params.headers] | <code>Object</code> | <code></code> | Additional headers for private PSK details. The key-value pairs represent header names and values. |
 | [params.publicHeaders] | <code>Object</code> | <code></code> | Additional headers for public PSK details. The key-value pairs represent header names and values. |
-| [params.disableEncryption] | <code>Object</code> | <code>false</code> | Turns off encryption of private memos and data |
+| [params.disableEncryption] | <code>Boolean</code> | <code>false</code> | Turns off encryption of private memos and data |
+| [params.minFulfillRetryWait] | <code>Number</code> |  | Minimum amount of time to wait before retrying fulfillment |
+| [params.maxFulfillRetryWait] | <code>Number</code> |  | Maximum amount of time to wait before retrying fulfillment |
 
 <a name="module_PSK..generateParams"></a>
 
@@ -410,7 +410,9 @@ Create a payment request for use in the IPR transport protocol.
 | [params.data] | <code>Buffer</code> | <code></code> | Additional data to include in the request |
 | [params.headers] | <code>Object</code> | <code></code> | Additional headers for private details. The key-value pairs represent header names and values. |
 | [params.publicHeaders] | <code>Object</code> | <code></code> | Additional headers for public details. The key-value pairs represent header names and values. |
-| [params.disableEncryption] | <code>Object</code> | <code>false</code> | Turns off encryption of private memos and data |
+| [params.disableEncryption] | <code>Boolean</code> | <code>false</code> | Turns off encryption of private memos and data |
+| [params.minFulfillRetryWait] | <code>Number</code> |  | Minimum amount of time to wait before retrying fulfillment |
+| [params.maxFulfillRetryWait] | <code>Number</code> |  | Maximum amount of time to wait before retrying fulfillment |
 
 <a name="module_IPR..listen"></a>
 

--- a/docs/README.template.md
+++ b/docs/README.template.md
@@ -133,7 +133,7 @@ const { sharedSecret, destinationAccount } = ILP.PSK.generateParams({
   const { packet, condition } = ILP.PSK.createPacketAndCondition({
     sharedSecret,
     destinationAccount,
-    destinationAmount: '10',
+    destinationAmount: '10', // denominated in the ledger's base unit
   })
 
   const quote = await ILP.ILQP.quoteByPacket(sender, packet)
@@ -182,7 +182,7 @@ const receiver = new FiveBellsLedgerPlugin({
 
 (async function () {
   const stopListening = await ILP.IPR.listen(receiver, {
-    secret: Buffer.from('secret', 'utf8')
+    receiverSecret: Buffer.from('secret', 'utf8')
   }, async function ({ transfer, fulfill }) {
     console.log('got transfer:', transfer)
 
@@ -192,9 +192,9 @@ const receiver = new FiveBellsLedgerPlugin({
   })
 
   const { packet, condition } = ILP.IPR.createPacketAndCondition({
-    secret: Buffer.from('secret', 'utf8'),
+    receiverSecret: Buffer.from('secret', 'utf8'),
     destinationAccount: receiver.getAccount(),
-    destinationAmount: '10',
+    destinationAmount: '10', // denominated in the ledger's base unit
   })
 
   // Note the user of this module must implement the method for

--- a/src/lib/ipr.js
+++ b/src/lib/ipr.js
@@ -21,7 +21,9 @@ const cryptoHelper = require('../utils/crypto')
   * @param {Buffer} [params.data=null] Additional data to include in the request
   * @param {Object} [params.headers=null] Additional headers for private details. The key-value pairs represent header names and values.
   * @param {Object} [params.publicHeaders=null] Additional headers for public details. The key-value pairs represent header names and values.
-  * @param {Object} [params.disableEncryption=false] Turns off encryption of private memos and data
+  * @param {Boolean} [params.disableEncryption=false] Turns off encryption of private memos and data
+  * @param {Number} [params.minFulfillRetryWait=250] Minimum amount of time (in ms) to wait before retrying fulfillment
+  * @param {Number} [params.maxFulfillRetryWait=1000] Maximum amount of time (in ms) to wait before retrying fulfillment
   *
   * @return {Object} Payment request
   */

--- a/src/lib/psk.js
+++ b/src/lib/psk.js
@@ -21,7 +21,9 @@ const assert = require('assert')
   * @param {Buffer} [params.data=null] Additional data to include in the request
   * @param {Object} [params.headers=null] Additional headers for private PSK details. The key-value pairs represent header names and values.
   * @param {Object} [params.publicHeaders=null] Additional headers for public PSK details. The key-value pairs represent header names and values.
-  * @param {Object} [params.disableEncryption=false] Turns off encryption of private memos and data
+  * @param {Boolean} [params.disableEncryption=false] Turns off encryption of private memos and data
+  * @param {Number} [params.minFulfillRetryWait=250] Minimum amount of time (in ms) to wait before retrying fulfillment
+  * @param {Number} [params.maxFulfillRetryWait=1000] Maximum amount of time (in ms) to wait before retrying fulfillment
   *
   * @return {Object} Payment request
   */

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,6 +3,7 @@
 const isUndefined = require('lodash/fp/isUndefined')
 const omitUndefined = require('lodash/fp/omitBy')(isUndefined)
 const startsWith = require('lodash/fp/startsWith')
+const debug = require('debug')('ilp:utils')
 const DEFAULT_CONNECT_TIMEOUT = 10000
 
 function safeConnect (plugin, timeoutOption) {
@@ -23,11 +24,38 @@ function wait (duration) {
   return new Promise((resolve) => setTimeout(resolve, duration))
 }
 
+function retryPromise ({
+  callback,
+  minWait,
+  maxWait,
+  stopWaiting
+}) {
+  return callback().catch((e) => {
+    debug('callback retry failed:', e)
+    if ((new Date()) > (new Date(stopWaiting))) {
+      debug('retry expiry of', stopWaiting, 'reached.')
+      throw new Error('retry expiry of ' + stopWaiting + ' reached.')
+    }
+
+    debug('retrying callback in', minWait, 'ms...')
+    return wait(Math.min(minWait, maxWait)).then(() => {
+      debug('retrying callback')
+      return retryPromise({
+        callback,
+        stopWaiting,
+        maxWait,
+        minWait: minWait * 2
+      })
+    })
+  })
+}
+
 module.exports = {
   xor,
   wait,
   startsWith,
   safeConnect,
+  retryPromise,
   omitUndefined,
   isUndefined
 }

--- a/test/utilSpec.js
+++ b/test/utilSpec.js
@@ -132,4 +132,40 @@ binary data goes here`
         })
     })
   })
+
+  describe('retryPromise', () => {
+    beforeEach(function () {
+      this.minWait = 10
+      this.maxWait = 10
+
+      this.stopWaiting = new Date()
+      this.stopWaiting.setSeconds(this.stopWaiting.getSeconds + 1)
+    })
+
+    it('should retry a promise', function * () {
+      let counter = 0
+      const callback = () => {
+        if (counter++ < 3) {
+          return Promise.reject(new Error('please retry'))
+        }
+        return Promise.resolve('success!')
+      }
+
+      yield Utils.retryPromise({
+        callback,
+        minWait: this.minWait,
+        maxWait: this.maxWait,
+        stopWaiting: this.stopWaiting
+      })
+    })
+
+    it('should stop retring after expiry', function * () {
+      yield assert.isRejected(Utils.retryPromise({
+        callback: () => Promise.reject(new Error('please retry')),
+        minWait: this.minWait,
+        maxWait: this.maxWait,
+        stopWaiting: (new Date())
+      }), /retry expiry of .* reached/)
+    })
+  })
 })


### PR DESCRIPTION
If `fulfillCondition` fails in the `fulfill` callback, it will keep retrying until the transfer's expiry. If it still has not succeeded at that point, it will reject.