### PR TITLE
fix: print quote errors when err.message is undefined

### DIFF
--- a/src/lib/ilqp.js
+++ b/src/lib/ilqp.js
@@ -29,7 +29,7 @@ function * _handleConnectorResponses (connectors, promises) {
         throw new Error('got empty quote response: ' + quote)
       }
     } catch (err) {
-      errors.push(connectors[c] + ': ' + err.message)
+      errors.push(connectors[c] + ': ' + (err.message || err))
     }
   }
 


### PR DESCRIPTION
For some types of errors, `err.message` is undefined. For instance, `No route found from: us.usd.nexus.admin to: us.usd.grifiti.admin.XnR_QBPlqx8SajwF_3e7wkHMnQUs0DnRg` will be printed as:

```
May 09 18:10:06 ip-172-16-0-11 ilp-kit[15027]: [api] Error: Errors occurred during quoting: us.usd.nexus.stefan: undefined
May 09 18:10:06 ip-172-16-0-11 ilp-kit[15027]: [api]     at _handleConnectorResponses (/opt/ilp-kit/node_modules/ilp/src/lib/ilqp.js:40:11)
May 09 18:10:06 ip-172-16-0-11 ilp-kit[15027]: [api]     at _handleConnectorResponses.throw (<anonymous>)
May 09 18:10:06 ip-172-16-0-11 ilp-kit[15027]: [api]     at onRejected (/opt/ilp-kit/node_modules/co/index.js:81:24)
May 09 18:10:06 ip-172-16-0-11 ilp-kit[15027]: [api]     at process._tickCallback (internal/process/next_tick.js:109:7)
```

This patch falls back to casting the error as a string in case the message property is not set or empty.