### PR TITLE
Feat: add listen all function for plugin factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,22 @@ Listen on a plugin for incoming PSK payments, and auto-generate fulfillments.
 | [params.allowOverPayment] | <code>Buffer</code> | <code>false</code> | Accept payments with higher amounts than expected |
 | callback | <code>IncomingCallback</code> |  | Called after an incoming payment is validated. |
 
+<a name="module_PSK..listenAll"></a>
+
+### PSK~listenAll(factory, params, callback) ⇒ <code>Object</code>
+Listen on a ILP plugin bells factory for incoming PSK payments, and auto-generate fulfillments.
+
+**Kind**: inner method of <code>[PSK](#module_PSK)</code>  
+**Returns**: <code>Object</code> - Payment request  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| factory | <code>Object</code> |  | Plugin bells factory to listen on |
+| params | <code>Object</code> |  | Parameters for creating payment request |
+| params.receiverSecret | <code>Buffer</code> |  | secret used to generate the shared secret and the extra segments of destinationAccount |
+| [params.allowOverPayment] | <code>Boolean</code> | <code>false</code> | Accept payments with higher amounts than expected |
+| callback | <code>IncomingCallback</code> |  | Called after an incoming payment is validated. |
+
 <a name="module_PSK..IncomingCallback"></a>
 
 ### PSK~IncomingCallback : <code>function</code>
@@ -496,6 +512,22 @@ Listen on a plugin for incoming IPR payments, and auto-generate fulfillments.
 | params | <code>Object</code> |  | Parameters for creating payment request |
 | params.secret | <code>Buffer</code> |  | Secret to generate fulfillments with |
 | [params.allowOverPayment] | <code>Buffer</code> | <code>false</code> | Accept payments with higher amounts than expected |
+| callback | <code>IncomingCallback</code> |  | Called after an incoming payment is validated. |
+
+<a name="module_IPR..listenAll"></a>
+
+### IPR~listenAll(factory, params, callback) ⇒ <code>Object</code>
+Listen on a ILP plugin bells factory for incoming IPR payments, and auto-generate fulfillments.
+
+**Kind**: inner method of <code>[IPR](#module_IPR)</code>  
+**Returns**: <code>Object</code> - Payment request  
+
+| Param | Type | Default | Description |
+| --- | --- | --- | --- |
+| factory | <code>Object</code> |  | Plugin bells factory to listen on |
+| params | <code>Object</code> |  | Parameters for creating payment request |
+| params.generateReceiverSecret | <code>function</code> |  | function that returns receiver secret for a given username |
+| [params.allowOverPayment] | <code>Boolean</code> | <code>false</code> | Accept payments with higher amounts than expected |
 | callback | <code>IncomingCallback</code> |  | Called after an incoming payment is validated. |
 
 <a name="module_IPR..IncomingCallback"></a>

--- a/src/lib/ipr.js
+++ b/src/lib/ipr.js
@@ -146,10 +146,16 @@ function listen (plugin, params, callback) {
   return Transport.listen(plugin, params, callback, 'ipr')
 }
 
+// TODO: apidoc
+function listenAll (factory, params, callback) {
+  return Transport.listenAll(factory, params, callback, 'ipr')
+}
+
 module.exports = {
   createPacketAndCondition,
   createIPR,
   encodeIPR,
   decodeIPR,
-  listen
+  listen,
+  listenAll
 }

--- a/src/lib/ipr.js
+++ b/src/lib/ipr.js
@@ -146,7 +146,17 @@ function listen (plugin, params, callback) {
   return Transport.listen(plugin, params, callback, 'ipr')
 }
 
-// TODO: apidoc
+/**
+  * Listen on a ILP plugin bells factory for incoming IPR payments, and auto-generate fulfillments.
+  *
+  * @param {Object} factory Plugin bells factory to listen on
+  * @param {Object} params Parameters for creating payment request
+  * @param {Function} params.generateReceiverSecret function that returns receiver secret for a given username
+  * @param {Boolean} [params.allowOverPayment=false] Accept payments with higher amounts than expected
+  * @param {IncomingCallback} callback Called after an incoming payment is validated.
+  *
+  * @return {Object} Payment request
+  */
 function listenAll (factory, params, callback) {
   return Transport.listenAll(factory, params, callback, 'ipr')
 }

--- a/src/lib/psk.js
+++ b/src/lib/psk.js
@@ -83,10 +83,38 @@ function listen (plugin, rawParams, callback) {
   return Transport.listen(plugin, params, callback, 'psk')
 }
 
+/**
+  * Listen on a ILP plugin bells factory for incoming PSK payments, and auto-generate fulfillments.
+  *
+  * @param {Object} factory Plugin bells factory to listen on
+  * @param {Object} params Parameters for creating payment request
+  * @param {Function} params.receiverSecret secret used to generate the shared secret and the extra segments of destinationAccount
+  * @param {Buffer} [params.allowOverPayment=false] Accept payments with higher amounts than expected
+  * @param {IncomingCallback} callback Called after an incoming payment is validated.
+  *
+  * @return {Object} Payment request
+  */
+function listenAll (factory, rawParams, callback) {
+  assert(Buffer.isBuffer(rawParams.receiverSecret), 'params.receiverSecret must be a buffer')
+
+  function generateReceiverSecret (address) {
+    const params = generateParams({
+      destinationAccount: address,
+      receiverSecret: rawParams.receiverSecret
+    })
+
+    return Buffer.from(params.sharedSecret, 'base64')
+  }
+
+  const params = Object.assign({}, rawParams, { generateReceiverSecret })
+  return Transport.listenAll(factory, params, callback, 'psk')
+}
+
 module.exports = {
   createPacketAndCondition,
   generateParams,
   listen,
+  listenAll,
   parseDetails: Details.parseDetails,
   createDetails: Details.createDetails,
   parsePacketAndDetails: Details.parsePacketAndDetails

--- a/src/lib/psk.js
+++ b/src/lib/psk.js
@@ -88,8 +88,8 @@ function listen (plugin, rawParams, callback) {
   *
   * @param {Object} factory Plugin bells factory to listen on
   * @param {Object} params Parameters for creating payment request
-  * @param {Function} params.receiverSecret secret used to generate the shared secret and the extra segments of destinationAccount
-  * @param {Buffer} [params.allowOverPayment=false] Accept payments with higher amounts than expected
+  * @param {Buffer} params.receiverSecret secret used to generate the shared secret and the extra segments of destinationAccount
+  * @param {Boolean} [params.allowOverPayment=false] Accept payments with higher amounts than expected
   * @param {IncomingCallback} callback Called after an incoming payment is validated.
   *
   * @return {Object} Payment request
@@ -98,12 +98,8 @@ function listenAll (factory, rawParams, callback) {
   assert(Buffer.isBuffer(rawParams.receiverSecret), 'params.receiverSecret must be a buffer')
 
   function generateReceiverSecret (address) {
-    const params = generateParams({
-      destinationAccount: address,
-      receiverSecret: rawParams.receiverSecret
-    })
-
-    return Buffer.from(params.sharedSecret, 'base64')
+    // The listen code already calls accountToSharedSecret
+    return rawParams.receiverSecret
   }
 
   const params = Object.assign({}, rawParams, { generateReceiverSecret })

--- a/src/lib/transport.js
+++ b/src/lib/transport.js
@@ -112,14 +112,14 @@ function * listenAll (factory, {
 }, callback) {
   assert(factory && typeof factory === 'object', 'factory must be an object')
   assert(typeof callback === 'function', 'callback must be a function')
-  assert(typeof genereateReceiverSecret === 'function', 'opts.generateReceiverSecret must be a function')
+  assert(typeof generateReceiverSecret === 'function', 'opts.generateReceiverSecret must be a function')
 
   yield safeConnect(factory)
   function * autoFulfillCondition (username, transfer) {
     const pluginAsUser = {
-      getAccount: factory.getAccountAs.bind(username),
-      rejectIncomingTransfer: factory.rejectIncomingTransferAs.bind(username),
-      fulfillCondition: factory.fulfillConditionAs.bind(username)
+      getAccount: factory.getAccountAs.bind(factory, username),
+      rejectIncomingTransfer: factory.rejectIncomingTransferAs.bind(factory, username),
+      fulfillCondition: factory.fulfillConditionAs.bind(factory, username)
     }
 
     const receiverSecret = generateReceiverSecret(pluginAsUser.getAccount())


### PR DESCRIPTION
Allows you to listen on many plugins while just registering one event listener. Only compatible with the `ilp-plugin-bells` Factory class. `ILP.PSK.listenAll` takes the same receiver secret used for the `generateParams` function.