### PR TITLE
feat: spsp.sendPayment relay rejection reasons

### DIFF
--- a/src/lib/spsp.js
+++ b/src/lib/spsp.js
@@ -222,10 +222,10 @@ function * sendPayment (plugin, payment) {
       resolve({ fulfillment })
     }
 
-    function cancel (transfer) {
+    function cancel (transfer, reason) {
       if (transfer.id !== payment.id) return
       remove()
-      reject(new Error('transfer ' + payment.id + ' failed.'))
+      reject(Object.assign(new Error('transfer ' + payment.id + ' failed.'), reason))
     }
 
     plugin.on('outgoing_fulfill', fulfill)
@@ -246,8 +246,6 @@ function * sendPayment (plugin, payment) {
 
   return yield listen
 }
-
-/**
 
 /**
   * Parameters for an SPSP payment

--- a/test/spspSpec.js
+++ b/test/spspSpec.js
@@ -185,7 +185,7 @@ describe('SPSP', function () {
 
       it('should reject if payment times out', function * () {
         this.plugin.sendTransfer = (transfer) => {
-          this.plugin.emit('outgoing_cancel', transfer)
+          this.plugin.emit('outgoing_cancel', transfer, {name: 'Foo'})
           return Promise.resolve(null)
         }
         
@@ -195,12 +195,12 @@ describe('SPSP', function () {
 
       it('should reject if payment is rejected', function * () {
         this.plugin.sendTransfer = (transfer) => {
-          this.plugin.emit('outgoing_reject', transfer)
+          this.plugin.emit('outgoing_reject', transfer, {message: 'override the message'})
           return Promise.resolve(null)
         }
         
         yield expect(SPSP.sendPayment(this.plugin, this.payment))
-          .to.eventually.be.rejectedWith(/transfer .+ failed/)
+          .to.eventually.be.rejectedWith('override the message')
       })
     })
   })


### PR DESCRIPTION
`spsp.sendPayment()` should reject with the rejection/cancellation reason, not just a generic error.

Related to https://github.com/interledgerjs/ilp-kit/issues/400