### PR TITLE
fix: call isConnected()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ function createPlugin (pluginOptions?: any, pluginModuleName: string = DEFAULT_P
  * @param plugin The plugin used to connect to the upstream service
  */
 async function fetchConfig (plugin: PluginApi.PluginV2): Promise<ILDCP.IldcpResponse> {
-  if (!plugin.isConnected) {
+  if (!plugin.isConnected()) {
     throw Error('Plugin must be connected to get config.')
   }
   return ILDCP.fetch(plugin.sendData.bind(plugin))

--- a/src/lib/spsp.ts
+++ b/src/lib/spsp.ts
@@ -70,7 +70,7 @@ export interface PayOptions {
 
 export async function pay (plugin: PluginV2, options: PayOptions): Promise<Receipt> {
   const { receiver, sourceAmount, data } = options
-  const pluginWasConnected = plugin.isConnected
+  const pluginWasConnected = plugin.isConnected()
   const [ response ] = await Promise.all([
     query(receiver),
     plugin.connect()


### PR DESCRIPTION
`isConnected` is a function -- since it was just testing the property it was always truthy.